### PR TITLE
examples: Updated to use upZenohClient

### DIFF
--- a/pubsub/src/main_pub.cpp
+++ b/pubsub/src/main_pub.cpp
@@ -81,7 +81,7 @@ std::uint8_t* getCounter() {
     return &counter;
 }
 
-UCode sendMessage(upZenohClient *transport,
+UCode sendMessage(std::shared_ptr<upZenohClient> transport,
                   UUri &uri,
                   std::uint8_t *buffer,
                   size_t size) {
@@ -112,11 +112,10 @@ int main(int argc,
     signal(SIGINT, signalHandler);
     
     UStatus status;
-    upZenohClient *transport = &upZenohClient::instance();
+    std::shared_ptr<upZenohClient> transport = upZenohClient::instance();
 
     /* Initialize zenoh utransport */
-    status = transport->init();
-    if (UCode::OK != status.code()) {
+    if (nullptr == transport) {
         spdlog::error("upZenohClientinit failed");
         return -1;
     }
@@ -146,13 +145,6 @@ int main(int argc,
         }
         
         sleep(1);
-    }
-
-     /* Terminate zenoh utransport */
-    status = transport->term();
-    if (UCode::OK != status.code()) {
-        spdlog::error("upZenohClient term failed");
-        return -1;
     }
 
     return 0;

--- a/pubsub/src/main_pub.cpp
+++ b/pubsub/src/main_pub.cpp
@@ -29,7 +29,7 @@
 #include <unistd.h> // For sleep
 
 #include <spdlog/spdlog.h>
-#include <up-client-zenoh-cpp/transport/zenohUTransport.h>
+#include <up-client-zenoh-cpp/client/upZenohClient.h>
 #include <up-cpp/uuid/factory/Uuidv8Factory.h>
 #include <up-cpp/uri/serializer/LongUriSerializer.h>
 #include <up-core-api/ustatus.pb.h>
@@ -81,7 +81,7 @@ std::uint8_t* getCounter() {
     return &counter;
 }
 
-UCode sendMessage(ZenohUTransport *transport,
+UCode sendMessage(upZenohClient *transport,
                   UUri &uri,
                   std::uint8_t *buffer,
                   size_t size) {
@@ -112,12 +112,12 @@ int main(int argc,
     signal(SIGINT, signalHandler);
     
     UStatus status;
-    ZenohUTransport *transport = &ZenohUTransport::instance();
+    upZenohClient *transport = &upZenohClient::instance();
 
     /* Initialize zenoh utransport */
     status = transport->init();
     if (UCode::OK != status.code()) {
-        spdlog::error("ZenohUTransport init failed");
+        spdlog::error("upZenohClientinit failed");
         return -1;
     }
     
@@ -151,7 +151,7 @@ int main(int argc,
      /* Terminate zenoh utransport */
     status = transport->term();
     if (UCode::OK != status.code()) {
-        spdlog::error("ZenohUTransport term failed");
+        spdlog::error("upZenohClient term failed");
         return -1;
     }
 

--- a/pubsub/src/main_sub.cpp
+++ b/pubsub/src/main_sub.cpp
@@ -96,11 +96,10 @@ int main(int argc,
     signal(SIGINT, signalHandler);
 
     UStatus status;
-    upZenohClient *transport = &upZenohClient::instance();
+    std::shared_ptr<upZenohClient> transport = upZenohClient::instance();
 
     /* init zenoh utransport */
-    status = transport->init();
-    if (UCode::OK != status.code()){
+    if (nullptr == transport){
         spdlog::error("upZenohClient init failed");
         return -1;
     }
@@ -141,13 +140,6 @@ int main(int argc,
             spdlog::error("unregisterListener failed for {}", uriStrings[i]);
             return -1;
         }
-    }
-
-    /* term zenoh utransport */
-    status = transport->term();
-    if (UCode::OK != status.code()) {
-        spdlog::error("upZenohClient term failed");
-        return -1;
     }
 
     return 0;

--- a/pubsub/src/main_sub.cpp
+++ b/pubsub/src/main_sub.cpp
@@ -27,7 +27,7 @@
 #include <iostream>
 #include <spdlog/spdlog.h>
 #include <unistd.h> // For sleep
-#include <up-client-zenoh-cpp/transport/zenohUTransport.h>
+#include <up-client-zenoh-cpp/client/upZenohClient.h>
 #include <up-cpp/uri/serializer/LongUriSerializer.h>
 
 using namespace uprotocol::utransport;
@@ -96,12 +96,12 @@ int main(int argc,
     signal(SIGINT, signalHandler);
 
     UStatus status;
-    ZenohUTransport *transport = &ZenohUTransport::instance();
+    upZenohClient *transport = &upZenohClient::instance();
 
     /* init zenoh utransport */
     status = transport->init();
     if (UCode::OK != status.code()){
-        spdlog::error("ZenohUTransport init failed");
+        spdlog::error("upZenohClient init failed");
         return -1;
     }
 
@@ -146,7 +146,7 @@ int main(int argc,
     /* term zenoh utransport */
     status = transport->term();
     if (UCode::OK != status.code()) {
-        spdlog::error("ZenohUTransport term failed");
+        spdlog::error("upZenohClient term failed");
         return -1;
     }
 

--- a/rpc/src/main_rpc_client.cpp
+++ b/rpc/src/main_rpc_client.cpp
@@ -55,7 +55,7 @@ UPayload sendRPC(UUri& uri) {
 
     UPayload payload(buffer, sizeof(buffer), UPayloadType::VALUE);
     /* send the RPC request , a future is returned from invokeMethod */
-    std::future<UPayload> result = upZenohClient::instance().invokeMethod(uri, payload, attributes);
+    std::future<UPayload> result = upZenohClient::instance()->invokeMethod(uri, payload, attributes);
 
     if (!result.valid()) {
         spdlog::error("Future is invalid");
@@ -78,11 +78,10 @@ int main(int argc,
     signal(SIGINT, signalHandler);
 
     UStatus status;
-    upZenohClient *rpcClient = &upZenohClient::instance();
+    std::shared_ptr<upZenohClient> rpcClient = upZenohClient::instance();
 
     /* init RPC client */
-    status = rpcClient->init();
-    if (UCode::OK != status.code()) {
+    if (nullptr == rpcClient) {
         spdlog::error("init failed");
         return -1;
     }
@@ -101,13 +100,6 @@ int main(int argc,
         }
 
         sleep(1);
-    }
-
-    /* term RPC client */
-    status = rpcClient->term();
-    if (UCode::OK != status.code()) {
-        spdlog::error("term failed");
-        return -1;
     }
 
     return 0;

--- a/rpc/src/main_rpc_client.cpp
+++ b/rpc/src/main_rpc_client.cpp
@@ -26,7 +26,7 @@
 #include <csignal>
 #include <unistd.h>
 #include <spdlog/spdlog.h>
-#include <up-client-zenoh-cpp/rpc/zenohRpcClient.h>
+#include <up-client-zenoh-cpp/client/upZenohClient.h>
 #include <up-cpp/uuid/factory/Uuidv8Factory.h>
 #include <up-cpp/uri/serializer/LongUriSerializer.h>
 
@@ -55,7 +55,7 @@ UPayload sendRPC(UUri& uri) {
 
     UPayload payload(buffer, sizeof(buffer), UPayloadType::VALUE);
     /* send the RPC request , a future is returned from invokeMethod */
-    std::future<UPayload> result = ZenohRpcClient::instance().invokeMethod(uri, payload, attributes);
+    std::future<UPayload> result = upZenohClient::instance().invokeMethod(uri, payload, attributes);
 
     if (!result.valid()) {
         spdlog::error("Future is invalid");
@@ -78,7 +78,7 @@ int main(int argc,
     signal(SIGINT, signalHandler);
 
     UStatus status;
-    ZenohRpcClient *rpcClient = &ZenohRpcClient::instance();
+    upZenohClient *rpcClient = &upZenohClient::instance();
 
     /* init RPC client */
     status = rpcClient->init();

--- a/rpc/src/main_rpc_server.cpp
+++ b/rpc/src/main_rpc_server.cpp
@@ -63,7 +63,7 @@ class RpcListener : public UListener {
             UAttributes responseAttributes = builder.build();
 
             /* Send the response */
-            return upZenohClient::instance().send(uri, responsePayload, responseAttributes);
+            return upZenohClient::instance()->send(uri, responsePayload, responseAttributes);
         }
 };
 
@@ -80,11 +80,10 @@ int main(int argc,
     signal(SIGINT, signalHandler);
 
     UStatus status;
-    upZenohClient *transport = &upZenohClient::instance();
+    std::shared_ptr<upZenohClient> transport = upZenohClient::instance();
 
     /* init zenoh utransport */
-    status = transport->init();
-    if (UCode::OK != status.code()) {
+    if (nullptr == transport) {
         spdlog::error("upZenohClient init failed");
         return -1;
     }
@@ -93,6 +92,7 @@ int main(int argc,
 
     /* register listener to handle RPC requests */
     status = transport->registerListener(rpcUri, listener);
+
     if (UCode::OK != status.code()) {
         spdlog::error("registerListener failed");
         return -1;
@@ -105,13 +105,6 @@ int main(int argc,
     status = transport->unregisterListener(rpcUri, listener);
     if (UCode::OK != status.code()) {
         spdlog::error("unregisterListener failed");
-        return -1;
-    }
-
-    /* term zenoh utransport */
-    status = transport->term();
-    if (UCode::OK != status.code()) {
-        spdlog::error("upZenohClient term failed");
         return -1;
     }
 

--- a/rpc/src/main_rpc_server.cpp
+++ b/rpc/src/main_rpc_server.cpp
@@ -25,7 +25,7 @@
 #include <chrono>
 #include <csignal>
 #include <unistd.h>
-#include <up-client-zenoh-cpp/transport/zenohUTransport.h>
+#include <up-client-zenoh-cpp/client/upZenohClient.h>
 #include <up-cpp/uuid/factory/Uuidv8Factory.h>
 #include <up-cpp/uri/serializer/LongUriSerializer.h>
 #include <spdlog/spdlog.h>
@@ -63,7 +63,7 @@ class RpcListener : public UListener {
             UAttributes responseAttributes = builder.build();
 
             /* Send the response */
-            return ZenohUTransport::instance().send(uri, responsePayload, responseAttributes);
+            return upZenohClient::instance().send(uri, responsePayload, responseAttributes);
         }
 };
 
@@ -80,12 +80,12 @@ int main(int argc,
     signal(SIGINT, signalHandler);
 
     UStatus status;
-    ZenohUTransport *transport = &ZenohUTransport::instance();
+    upZenohClient *transport = &upZenohClient::instance();
 
     /* init zenoh utransport */
     status = transport->init();
     if (UCode::OK != status.code()) {
-        spdlog::error("ZenohUTransport init failed");
+        spdlog::error("upZenohClient init failed");
         return -1;
     }
 
@@ -111,7 +111,7 @@ int main(int argc,
     /* term zenoh utransport */
     status = transport->term();
     if (UCode::OK != status.code()) {
-        spdlog::error("ZenohUTransport term failed");
+        spdlog::error("upZenohClient term failed");
         return -1;
     }
 


### PR DESCRIPTION
Update examples to use upZenohClient class instead of zenohRpcClient and zenohUTransport.